### PR TITLE
Canal Excavator Compatibility

### DIFF
--- a/data.lua
+++ b/data.lua
@@ -12,3 +12,5 @@ require("prototypes.equipment")
 require("prototypes.shortcuts")
 require("prototypes.transport-belts")
 require("prototypes.wall")
+
+require("prototypes.compatibility.data")

--- a/info.json
+++ b/info.json
@@ -5,6 +5,6 @@
   "author": "Bartz24, LogicDolphin",
   "factorio_version": "2.0",
   "space_travel_required": true,
-  "dependencies": ["base >= 2.0.30", "space-age", "? alien-biomes", "? landing-pad-research", "? maraxsis", "? planet-muluna", "? Cerys-Moon-of-Fulgora", "? modules-t4"],
+  "dependencies": ["base >= 2.0.30", "space-age", "? alien-biomes", "? landing-pad-research", "? maraxsis", "? planet-muluna", "? Cerys-Moon-of-Fulgora", "? modules-t4", "? canal-excavator >= 1.9.0"],
   "description": "Adds a new militaristic planet to the game. Claim the defended post-apocalyptic planet and use its resources to build a new base."
 }

--- a/prototypes/compatibility/canal-excavator.lua
+++ b/prototypes/compatibility/canal-excavator.lua
@@ -1,0 +1,14 @@
+if not mods["canal-excavator"] then return end
+
+data:extend({{
+  type = "mod-data",
+  name = "canex-castra-config",
+  data_type = "canex-surface-config",
+  data = {
+    surfaceName = "castra",
+    localisation = {"space-location-name.castra"},
+    mineResult = "stone",
+    oreStartingAmount = 25,
+    tint = {r = 102, g = 48, b = 6}
+  },
+}})

--- a/prototypes/compatibility/data.lua
+++ b/prototypes/compatibility/data.lua
@@ -1,0 +1,1 @@
+require("prototypes.compatibility.canal-excavator")


### PR DESCRIPTION
Hi,

Some users of my [Canal Excavator](https://mods.factorio.com/mod/canal-excavator) mod asked me to implement compatibility with more planet mods.
Personally I think it's cleaner if the compatibility code is in the planet mod so let me know if you're okay with adding this.

Since, as far as I could find, you didn't have any other compatibility code in your project yet, I've added a basic structure I've seen and used in other projects. Furthermore, if you want you could change the dependency to hidden `(?)`, but I leave that up to you.

If you want it to be harder for players to create canals you could increase the `oreStartingAmount` to something higher, but 25 is already higher than on Nauvis.

Let me know what you think.